### PR TITLE
Add watchlist export

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a simple cross-platform script to export your movies in Trakt to Letterboxd
 
-To use run `python Trakt2Letterboxd.py` on your terminal. This will generate a csv file in the format required by Letterboxd. 
+To use run `python Trakt2Letterboxd.py` on your terminal. This will generate two csv files in the format required by
+Letterboxd. One titled 'trakt-exported-history.csv' (for movies you've seen) and one titled 'trakt-exported-watchlist.csv'
+(for movies you want to watch).
 
 Note: The script requires Python2.x to run, to install Python go to https://www.python.org/downloads/


### PR DESCRIPTION
I modified the API call function to accept an argument to determine which list of movies would be exported. The run function now calls it for both "history" and "watchlist" and exports two separate CSVs.